### PR TITLE
Protobuf headers and Releasetools

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -535,12 +535,27 @@ proto_generated_headers := $(patsubst %.pb$(my_proto_source_suffix),%.pb.h, $(pr
 proto_generated_objects := $(addprefix $(proto_generated_obj_dir)/, \
     $(patsubst %.proto,%.pb.o,$(proto_sources_fullpath)))
 
+define copy-proto-files
+$(if $(PRIVATE_PROTOC_OUTPUT), \
+   $(if $(call streq,$(PRIVATE_PROTOC_INPUT),$(PRIVATE_PROTOC_OUTPUT)),, \
+   $(eval proto_generated_path := $(dir $(subst $(PRIVATE_PROTOC_INPUT),$(PRIVATE_PROTOC_OUTPUT),$@)))
+   $(eval proto_target_files := $(patsubst %.pb$(PRIVATE_PROTOC_SUFFIX), %.pb.*, $@))
+   @mkdir -p $(dir $(proto_generated_path))
+   @echo "Protobuf relocation: $(proto_target_files) => $(proto_generated_path)"
+   @cp -f $(proto_target_files) $(proto_generated_path) ),)
+endef
+
+
 # Ensure the transform-proto-to-cc rule is only defined once in multilib build.
 ifndef $(my_prefix)_$(LOCAL_MODULE_CLASS)_$(LOCAL_MODULE)_proto_defined
 $(proto_generated_sources): PRIVATE_PROTO_INCLUDES := $(TOP)
 $(proto_generated_sources): PRIVATE_PROTOC_FLAGS := $(LOCAL_PROTOC_FLAGS) $(my_protoc_flags)
+$(proto_generated_sources): PRIVATE_PROTOC_OUTPUT := $(LOCAL_PROTOC_OUTPUT)
+$(proto_generated_sources): PRIVATE_PROTOC_INPUT := $(LOCAL_PATH)
+$(proto_generated_sources): PRIVATE_PROTOC_SUFFIX := $(my_proto_source_suffix)
 $(proto_generated_sources): $(proto_generated_sources_dir)/%.pb$(my_proto_source_suffix): %.proto $(PROTOC)
 	$(transform-proto-to-cc)
+	$(copy-proto-files)
 
 # This is just a dummy rule to make sure gmake doesn't skip updating the dependents.
 $(proto_generated_headers): $(proto_generated_sources_dir)/%.pb.h: $(proto_generated_sources_dir)/%.pb$(my_proto_source_suffix)

--- a/core/clear_vars.mk
+++ b/core/clear_vars.mk
@@ -293,6 +293,11 @@ LOCAL_MODULE_STEM_64:=
 LOCAL_CLANG_32:=
 LOCAL_CLANG_64:=
 
+LOCAL_PROTOC_OUTPUT:=
+
+# Include any vendor specific clear_vars.mk file
+-include $(TOPDIR)vendor/*/build/core/clear_vars.mk
+
 # Trim MAKEFILE_LIST so that $(call my-dir) doesn't need to
 # iterate over thousands of entries every time.
 # Leave the current makefile to make sure we don't break anything

--- a/tools/releasetools/sign_target_files_apks.py
+++ b/tools/releasetools/sign_target_files_apks.py
@@ -215,6 +215,10 @@ def ProcessTargetFiles(input_tf_zip, output_tf_zip, misc_info,
       print "rewriting %s with new keys." % (info.filename,)
       new_data = ReplaceCerts(data)
       common.ZipWriteStr(output_tf_zip, out_info, new_data)
+    elif info.filename.startswith("SYSTEM/etc/permissions/"):
+      print("rewriting %s with new keys." % info.filename)
+      new_data = ReplaceCerts(data)
+      common.ZipWriteStr(output_tf_zip, out_info, new_data)
     elif info.filename in ("SYSTEM/recovery-from-boot.p",
                            "SYSTEM/bin/install-recovery.sh"):
       rebuild_recovery = True


### PR DESCRIPTION
The first commit (releasetools: Replace key values in permission files during re-signing) fixes this error during compilation - insertkeys.py: error: Must specify a config file (keys.conf) AND mac_permissions.xml file(s)

The second commit (build : specify the path for protobuf headers) fixes this error - hardware/ril-caf/libril/RilSapSocket.h:22:55: fatal error: hardware/ril/librilutils/proto/sap-api.pb.h: No such file or directory
